### PR TITLE
sqlalchemy: Import String from sqlalchemy directly

### DIFF
--- a/magnum/db/sqlalchemy/alembic/versions/05d3e97de9ee_add_volume_driver.py
+++ b/magnum/db/sqlalchemy/alembic/versions/05d3e97de9ee_add_volume_driver.py
@@ -24,13 +24,11 @@ down_revision = '57fbdf2327a2'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('volume_driver',
-                  String(255, mysql_ndb_type=TINYTEXT), nullable=True))
+                  String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/2581ebaf0cb2_initial_migration.py
+++ b/magnum/db/sqlalchemy/alembic/versions/2581ebaf0cb2_initial_migration.py
@@ -25,11 +25,9 @@ down_revision = None
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
@@ -61,8 +59,7 @@ def upgrade():
         sa.Column('keypair_id', sa.String(length=255), nullable=True),
         sa.Column('image_id', sa.String(length=255), nullable=True),
         sa.Column('external_network_id', sa.String(length=255), nullable=True),
-        sa.Column('dns_nameserver', String(255, mysql_ndb_type=TINYTEXT),
-                  nullable=True),
+        sa.Column('dns_nameserver', String(255), nullable=True),
         sa.Column('apiserver_port', sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint('id'),
         mysql_ENGINE='InnoDB',

--- a/magnum/db/sqlalchemy/alembic/versions/35cff7c86221_add_private_network_to_baymodel.py
+++ b/magnum/db/sqlalchemy/alembic/versions/35cff7c86221_add_private_network_to_baymodel.py
@@ -25,14 +25,11 @@ down_revision = '3a938526b35d'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('fixed_network',
-                  String(255, mysql_ndb_type=TINYTEXT),
-                  nullable=True))
+                  String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/3be65537a94a_add_network_driver_baymodel_column.py
+++ b/magnum/db/sqlalchemy/alembic/versions/3be65537a94a_add_network_driver_baymodel_column.py
@@ -27,13 +27,11 @@ down_revision = '4e263f236334'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('network_driver',
-                  String(255, mysql_ndb_type=TINYTEXT), nullable=True))
+                  String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/461d798132c7_change_cluster_to_support_nodegroups.py
+++ b/magnum/db/sqlalchemy/alembic/versions/461d798132c7_change_cluster_to_support_nodegroups.py
@@ -29,9 +29,9 @@ from alembic import op  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
 from oslo_serialization import jsonutils  # noqa: E402
 from oslo_utils import uuidutils  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 from magnum.db.sqlalchemy import models  # noqa: E402
 

--- a/magnum/db/sqlalchemy/alembic/versions/47380964133d_add_network_subnet_fip_to_cluster.py
+++ b/magnum/db/sqlalchemy/alembic/versions/47380964133d_add_network_subnet_fip_to_cluster.py
@@ -23,18 +23,15 @@ revision = '47380964133d'
 down_revision = '461d798132c7'
 
 from alembic import op  # noqa: E402
-from oslo_db.sqlalchemy.types import String  # noqa: E402
 import sqlalchemy as sa  # noqa: E402
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 
 def upgrade():
     op.add_column('cluster', sa.Column('fixed_network',
-                  String(255, mysql_ndb_type=TINYTEXT),
-                  nullable=True))
+                  String(255), nullable=True))
     op.add_column('cluster', sa.Column('fixed_subnet',
-                  String(255, mysql_ndb_type=TINYTEXT),
-                  nullable=True))
+                  String(255), nullable=True))
     op.add_column('cluster', sa.Column('floating_ip_enabled',
                   sa.Boolean(create_constraint=False),
                   default=False))

--- a/magnum/db/sqlalchemy/alembic/versions/4956f03cabad_add_cluster_distro.py
+++ b/magnum/db/sqlalchemy/alembic/versions/4956f03cabad_add_cluster_distro.py
@@ -24,13 +24,11 @@ down_revision = '2d8657c0cdc'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('cluster_distro',
-                  String(255, mysql_ndb_type=TINYTEXT), nullable=True))
+                  String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/4ea34a59a64c_add_discovery_url_to_bay.py
+++ b/magnum/db/sqlalchemy/alembic/versions/4ea34a59a64c_add_discovery_url_to_bay.py
@@ -23,15 +23,12 @@ down_revision = '456126c6c9e9'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('bay',
                   sa.Column('discovery_url',
-                            String(255, mysql_ndb_type=TINYTEXT),
-                            nullable=True))
+                            String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/5518af8dbc21_rename_cert_uuid.py
+++ b/magnum/db/sqlalchemy/alembic/versions/5518af8dbc21_rename_cert_uuid.py
@@ -23,21 +23,17 @@ down_revision = '6f21dc920bb'
 
 from alembic import op  # noqa: E402  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TEXT  # noqa: E402
 
 
 def upgrade():
     op.alter_column('bay', 'ca_cert_uuid',
                     new_column_name='ca_cert_ref',
                     existing_type=sa.String(length=36),
-                    type_=String(512, mysql_ndb_type=TEXT),
-                    nullable=True)
+                    type_=String(512), nullable=True)
     op.alter_column('bay', 'magnum_cert_uuid',
                     new_column_name='magnum_cert_ref',
                     existing_type=sa.String(length=36),
-                    type_=String(512, mysql_ndb_type=TEXT),
-                    nullable=True)
+                    type_=String(512), nullable=True)

--- a/magnum/db/sqlalchemy/alembic/versions/592131657ca1_add_coe_column_to_baymodel.py
+++ b/magnum/db/sqlalchemy/alembic/versions/592131657ca1_add_coe_column_to_baymodel.py
@@ -24,24 +24,20 @@ down_revision = '4956f03cabad'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import magnum.conf  # noqa: E402
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 CONF = magnum.conf.CONF
 
 
 def upgrade():
-    op.add_column('baymodel', sa.Column('coe', String(255,
-                                        mysql_ndb_type=TINYTEXT),
+    op.add_column('baymodel', sa.Column('coe', String(255),
                                         nullable=True))
 
     baymodel = sa.sql.table('baymodel',
-                            sa.sql.column('coe', String(255,
-                                          mysql_ndb_type=TINYTEXT)))
+                            sa.sql.column('coe', String(255)))
 
     op.execute(
         baymodel.update().values({

--- a/magnum/db/sqlalchemy/alembic/versions/5d4caa6e0a42_create_trustee_for_each_bay.py
+++ b/magnum/db/sqlalchemy/alembic/versions/5d4caa6e0a42_create_trustee_for_each_bay.py
@@ -27,11 +27,9 @@ down_revision = 'bb42b7cad130'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
@@ -39,10 +37,8 @@ def upgrade():
                     new_column_name='trust_id',
                     existing_type=sa.String(255))
     op.add_column('bay', sa.Column('trustee_username',
-                  String(255, mysql_ndb_type=TINYTEXT),
-                  nullable=True))
+                  String(255), nullable=True))
     op.add_column('bay', sa.Column('trustee_user_id',
                   sa.String(length=255), nullable=True))
     op.add_column('bay', sa.Column('trustee_password',
-                  String(255, mysql_ndb_type=TINYTEXT),
-                  nullable=True))
+                  String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/7da8489d6a68_separated_ca_cert_for_etcd_and_front_.py
+++ b/magnum/db/sqlalchemy/alembic/versions/7da8489d6a68_separated_ca_cert_for_etcd_and_front_.py
@@ -26,17 +26,15 @@ down_revision = 'f1d8b0ab8b8d'
 
 from alembic import op  # noqa: E402  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('cluster', sa.Column('etcd_ca_cert_ref',
-                  String(512, mysql_ndb_type=TEXT),
+                  String(512),
                   nullable=True))
     op.add_column('cluster', sa.Column('front_proxy_ca_cert_ref',
-                  String(512, mysql_ndb_type=TEXT),
+                  String(512),
                   nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/966a99e70ff_add_proxy.py
+++ b/magnum/db/sqlalchemy/alembic/versions/966a99e70ff_add_proxy.py
@@ -23,20 +23,18 @@ down_revision = '6f21dc998bb'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('http_proxy',
-                                        String(255, mysql_ndb_type=TINYTEXT),
+                                        String(255),
                                         nullable=True))
     op.add_column('baymodel', sa.Column('https_proxy',
-                                        String(255, mysql_ndb_type=TINYTEXT),
+                                        String(255),
                                         nullable=True))
     op.add_column('baymodel', sa.Column('no_proxy',
-                                        String(255, mysql_ndb_type=TINYTEXT),
+                                        String(255),
                                         nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/ac92cbae311c_add_nodegoup_table.py
+++ b/magnum/db/sqlalchemy/alembic/versions/ac92cbae311c_add_nodegoup_table.py
@@ -29,7 +29,7 @@ from alembic import op  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 from magnum.db.sqlalchemy import models  # noqa: E402
 

--- a/magnum/db/sqlalchemy/alembic/versions/c04e925e65c2_nodegroups_v2.py
+++ b/magnum/db/sqlalchemy/alembic/versions/c04e925e65c2_nodegroups_v2.py
@@ -29,7 +29,7 @@ from alembic import op  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 
 def upgrade():

--- a/magnum/db/sqlalchemy/alembic/versions/e0653b2d5271_add_fixed_subnet_column_to_baymodel_table.py
+++ b/magnum/db/sqlalchemy/alembic/versions/e0653b2d5271_add_fixed_subnet_column_to_baymodel_table.py
@@ -23,14 +23,11 @@ down_revision = '68ce16dfd341'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('fixed_subnet',
-                                        String(255, mysql_ndb_type=TINYTEXT),
-                                        nullable=True))
+                                        String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/e647f5931da8_add_insecure_registry_to_baymodel.py
+++ b/magnum/db/sqlalchemy/alembic/versions/e647f5931da8_add_insecure_registry_to_baymodel.py
@@ -23,14 +23,11 @@ down_revision = '049f81f6f584'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('baymodel', sa.Column('insecure_registry',
-                                        String(255, mysql_ndb_type=TINYTEXT),
-                                        nullable=True))
+                                        String(255), nullable=True))

--- a/magnum/db/sqlalchemy/alembic/versions/fcb4efee8f8b_add_version_info_to_bay.py
+++ b/magnum/db/sqlalchemy/alembic/versions/fcb4efee8f8b_add_version_info_to_bay.py
@@ -23,19 +23,15 @@ down_revision = 'b1f612248cab'
 
 from alembic import op  # noqa: E402
 
-from oslo_db.sqlalchemy.types import String  # noqa: E402
+from sqlalchemy.types import String  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
-
-from sqlalchemy.dialects.mysql import TINYTEXT  # noqa: E402
 
 
 def upgrade():
     op.add_column('bay',
-                  sa.Column('coe_version', String(255,
-                            mysql_ndb_type=TINYTEXT),
+                  sa.Column('coe_version', String(255),
                             nullable=True))
     op.add_column('bay',
-                  sa.Column('container_version', String(255,
-                            mysql_ndb_type=TINYTEXT),
+                  sa.Column('container_version', String(255),
                             nullable=True))

--- a/magnum/db/sqlalchemy/models.py
+++ b/magnum/db/sqlalchemy/models.py
@@ -17,7 +17,6 @@ SQLAlchemy models for container service
 """
 
 from oslo_db.sqlalchemy import models
-from oslo_db.sqlalchemy.types import String
 from oslo_serialization import jsonutils
 import six.moves.urllib.parse as urlparse
 from sqlalchemy import Boolean
@@ -27,9 +26,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Integer
 from sqlalchemy import schema
 from sqlalchemy import Text
-from sqlalchemy.types import TypeDecorator, TEXT
-from sqlalchemy.dialects.mysql import TEXT as mysql_TEXT
-from sqlalchemy.dialects.mysql import TINYTEXT
+from sqlalchemy.types import TypeDecorator, TEXT, String
 
 import magnum.conf
 
@@ -128,27 +125,27 @@ class Cluster(Base):
     health_status = Column(String(20))
     health_status_reason = Column(JSONEncodedDict)
     create_timeout = Column(Integer())
-    discovery_url = Column(String(255, mysql_ndb_type=TINYTEXT))
+    discovery_url = Column(String(255))
     # TODO(wanghua): encrypt trust_id in db
     trust_id = Column(String(255))
-    trustee_username = Column(String(255, mysql_ndb_type=TINYTEXT))
+    trustee_username = Column(String(255))
     trustee_user_id = Column(String(255))
     # TODO(wanghua): encrypt trustee_password in db
-    trustee_password = Column(String(255, mysql_ndb_type=TINYTEXT))
-    coe_version = Column(String(255, mysql_ndb_type=TINYTEXT))
-    container_version = Column(String(255, mysql_ndb_type=TINYTEXT))
+    trustee_password = Column(String(255))
+    coe_version = Column(String(255))
+    container_version = Column(String(255))
     # (yuanying) if we use barbican,
     # cert_ref size is determined by below format
     # * http(s)://${DOMAIN_NAME}/v1/containers/${UUID}
     # as a result, cert_ref length is estimated to 312 chars.
     # but we can use another backend to store certs.
     # so, we use 512 chars to get some buffer.
-    ca_cert_ref = Column(String(512, mysql_ndb_type=mysql_TEXT))
-    magnum_cert_ref = Column(String(512, mysql_ndb_type=mysql_TEXT))
-    etcd_ca_cert_ref = Column(String(512, mysql_ndb_type=mysql_TEXT))
-    front_proxy_ca_cert_ref = Column(String(512, mysql_ndb_type=mysql_TEXT))
-    fixed_network = Column(String(255, mysql_ndb_type=TINYTEXT))
-    fixed_subnet = Column(String(255, mysql_ndb_type=TINYTEXT))
+    ca_cert_ref = Column(String(512))
+    magnum_cert_ref = Column(String(512))
+    etcd_ca_cert_ref = Column(String(512))
+    front_proxy_ca_cert_ref = Column(String(512))
+    fixed_network = Column(String(255))
+    fixed_subnet = Column(String(255))
     floating_ip_enabled = Column(Boolean, default=True)
     master_lb_enabled = Column(Boolean, default=False)
 
@@ -171,25 +168,25 @@ class ClusterTemplate(Base):
     master_flavor_id = Column(String(255))
     keypair_id = Column(String(255))
     external_network_id = Column(String(255))
-    fixed_network = Column(String(255, mysql_ndb_type=TINYTEXT))
-    fixed_subnet = Column(String(255, mysql_ndb_type=TINYTEXT))
-    network_driver = Column(String(255, mysql_ndb_type=TINYTEXT))
-    volume_driver = Column(String(255, mysql_ndb_type=TINYTEXT))
-    dns_nameserver = Column(String(255, mysql_ndb_type=TINYTEXT))
+    fixed_network = Column(String(255))
+    fixed_subnet = Column(String(255))
+    network_driver = Column(String(255))
+    volume_driver = Column(String(255))
+    dns_nameserver = Column(String(255))
     apiserver_port = Column(Integer())
     docker_volume_size = Column(Integer())
     docker_storage_driver = Column(String(255))
-    cluster_distro = Column(String(255, mysql_ndb_type=TINYTEXT))
-    coe = Column(String(255, mysql_ndb_type=TINYTEXT))
-    http_proxy = Column(String(255, mysql_ndb_type=TINYTEXT))
-    https_proxy = Column(String(255, mysql_ndb_type=TINYTEXT))
-    no_proxy = Column(String(255, mysql_ndb_type=TINYTEXT))
+    cluster_distro = Column(String(255))
+    coe = Column(String(255))
+    http_proxy = Column(String(255))
+    https_proxy = Column(String(255))
+    no_proxy = Column(String(255))
     registry_enabled = Column(Boolean, default=False)
     labels = Column(JSONEncodedDict)
     tls_disabled = Column(Boolean, default=False)
     public = Column(Boolean, default=False)
     server_type = Column(String(255))
-    insecure_registry = Column(String(255, mysql_ndb_type=TINYTEXT))
+    insecure_registry = Column(String(255))
     master_lb_enabled = Column(Boolean, default=False)
     floating_ip_enabled = Column(Boolean, default=True)
     hidden = Column(Boolean, default=False)


### PR DESCRIPTION
With dropping of MySQL NDB cluster support in oslo.db the String subclass that implemented specific options is gone [1]

[1]: Ia8b4ed8cd755d283bb773e55293457190b34c482

It's required in 2023.2 release for compatibility with oslo.db 14.1.0.

Change-Id: I4ae0943a9cfdf6ed96bcd9ca54d98d008f6a5573 (cherry picked from commit d18aa8ffa26cdddcf4ecae357824998f5db5307f)